### PR TITLE
Skip AeroLoad updates if it already exists

### DIFF
--- a/install.lua
+++ b/install.lua
@@ -278,7 +278,7 @@ function Install()
 					scriptObj.Parent = parent
 				elseif (obj and obj.ClassName == className) then
 					scriptObj = obj
-					if (scriptObj.Source ~= source) then
+					if (scriptObj.Source ~= source && obj.Name ~= "AeroLoad") then
 						scriptObj.Source = source
 						wasUpdated = true
 					else


### PR DESCRIPTION
When updating the framework today, I noticed that the TopBar stopped hiding itself and that my loading screen no longer worked, and noticed the update reset my AeroLoad script in ReplicatedFirst. This pull request makes it not update if the file already exists. For the times that AeroLoad _does_ need updated, this could be mentioned in the GUI and say they can see the changes needed on GitHub. 