### PR TITLE
Fixed Aero side of infinite yield bug

### DIFF
--- a/src/ServerStorage/Aero/Services/DataService.modulescript.lua
+++ b/src/ServerStorage/Aero/Services/DataService.modulescript.lua
@@ -240,7 +240,7 @@ function DataService:FlushAllConcurrent()
 		end)
 	end
 	globalCache:FlushAll()
-	coroutine.yield()
+	if (numCaches > 0) then coroutine.yield() end
 end
 
 
@@ -282,7 +282,7 @@ function DataService:Start()
 				end
 			end)()
 		end
-		coroutine.yield()
+		if (numBinded > 0) then coroutine.yield() end
 	end
 	
 	-- Flush cache:


### PR DESCRIPTION
Will no longer infinite yield if boundToCloseFuncs is 0 and will no longer infinite yield if the number of DataCaches is 0. This fixes the Aero side of the infinite yield bug, Roblox has yet to fix the bug on their end.