### PR TITLE
Protect against failed 'GetAsync' calls by marking the argument key a…

### DIFF
--- a/src/ServerStorage/Aero/Modules/DataStoreCache.SafeDataStore.modulescript.lua
+++ b/src/ServerStorage/Aero/Modules/DataStoreCache.SafeDataStore.modulescript.lua
@@ -51,7 +51,7 @@ function SafeDataStore.new(name, scope)
 end
 
 
-function SafeDataStore:Try(method, k, v)
+function SafeDataStore:Try(method, k, v, protected)
 	local budget = GetBudget(method)
 	if (budget == 0) then
 		-- Do something in later implementation
@@ -65,13 +65,23 @@ function SafeDataStore:Try(method, k, v)
 			value = v
 			break
 		elseif (i == MAX_ATTEMPTS) then
-			warn("DataStore " .. method .. " failed: " .. tostring(v))
+			local errMsg = "DataStore " .. method .. " failed: " .. tostring(v)
+			warn(errMsg)
 			self.Failed:Fire(method, k, tostring(v))
+
+			if (protected == true) then
+				return false, errMsg
+			end
 		else
 			wait(ATTEMPT_INTERVAL)
 		end
 	end
-	return value
+
+	if (protected == true) then
+		return true, value
+	else
+		return value
+	end
 end
 
 
@@ -82,6 +92,10 @@ end
 
 function SafeDataStore:GetAsync(key)
 	return self:Try("GetAsync", key)
+end
+
+function SafeDataStore:P_GetAsync(key)
+	return self:Try("GetAsync", key, nil, true)
 end
 
 

--- a/src/ServerStorage/Aero/Modules/DataStoreCache.modulescript.lua
+++ b/src/ServerStorage/Aero/Modules/DataStoreCache.modulescript.lua
@@ -71,6 +71,23 @@ function Cache:Load(key)
 	end
 end
 
+function Cache:P_Load(key)
+	if (self.DataStore) then
+		local v = nil
+		local success, value = self.DataStore:P_GetAsync(key)
+		if (success == true) then
+			v = {value, true}
+			self.Data[key] = v
+		else
+			-- if failed, 'value' will hold error message
+			v = value
+		end
+
+		return success, v
+	else
+		return false, 'nil DataStore'
+	end
+end
 
 function Cache:Flush(key, flushingAll)
 	if (not self.DataStore) then return end
@@ -124,6 +141,20 @@ function Cache:Get(key)
 	return value and value[1] or nil
 end
 
+function Cache:P_Get(key)
+	local value = self.Data[key]
+	if (value == nil) then
+		local success, value = self:P_Load(key)
+		if (success == true) then
+			value = value and value[1] or nil
+		end
+
+		return success, value
+	else
+		local v = value and value[1] or nil
+		return true, v
+	end
+end
 
 function Cache:Set(key, value)
 	local v = self.Data[key]

--- a/src/ServerStorage/Aero/Services/DataService.modulescript.lua
+++ b/src/ServerStorage/Aero/Services/DataService.modulescript.lua
@@ -124,6 +124,10 @@ function DataService:Get(player, key)
 	return self:GetPlayerCache(player):Get(key)
 end
 
+function DataService:P_Get(player, key)
+	return self:GetPlayerCache(player):P_Get(key)
+end
+
 
 function DataService:Remove(player, key)
 	self:GetPlayerCache(player):Remove(key)


### PR DESCRIPTION
…s 'corrupt'. Subsequent saves to this key will be ignored. This prevents data loss / key overwriting in the case of temporary DataStore outages when fetching keys. Ideally the developer would notify clients of a failure to fetch a key and suggest to re-join a game.

If saves are allowed on a key after a failure to fetch, code which assigns a default value to a key after a 'get' attempt returns 'nil' will overwrite user data for that key on the next save event.