### PR TITLE
Weird rejoin bug tempfix

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data.lua
+++ b/src/ServerStorage/Aero/Modules/Data.lua
@@ -93,7 +93,7 @@ function Data.new(name, scope)
 	-- Get cached 'data' object if available:
 	local ds = dataStoreService:GetDataStore(name, scope)
 	local self = dataPool[ds]
-	if (self) then return self end
+	if (self and not self._destroyed) then return self end
 
 	-- Create new 'data' object:
 	self = setmetatable({

--- a/src/ServerStorage/Aero/Modules/Data.lua
+++ b/src/ServerStorage/Aero/Modules/Data.lua
@@ -212,7 +212,7 @@ end
 
 function Data:Increment(key, increment)
 	assert(not self._destroyed, "Data already destroyed")
-	local value = self:Get(key, 0)
+	local success, value = self:Get(key, 0)
 	assert(type(value) == "number", "Cannot increment a non-number value")
 	assert(type(increment) == "number", "Increment must be a number")
 	value = (value + increment)


### PR DESCRIPTION
This change fixes a strange bug with players leaving and rejoining the same server. For whatever reason, if a player leaves the game and then rejoins the same server, even if ``PlayerLeftSaveInterval`` seconds have elapsed, the old data object will still be in the dataPool yet will be marked as destroyed, essentially breaking it.

This is meant only to be a temporary fix until the source of the issue is found.

Other fix: Fixed Data:Increment()