### PR TITLE
defaultVal being table fix

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data.lua
+++ b/src/ServerStorage/Aero/Modules/Data.lua
@@ -189,8 +189,8 @@ function Data:Get(key, defaultVal)
 	if (value == nil) then
 		success, value = self:_load(key)
 		if (success and value == nil and defaultVal ~= nil) then
-			value = defaultVal
-			self:Set(key, defaultVal)
+			value = typeof(defaultVal) ~= "table" and defaultVal or self.Shared.TableUtil.Copy(defaultVal)
+			self:Set(key, value)
 		end
 	end
 	return success, value


### PR DESCRIPTION
If the ``defaultVal`` passed to ``Data:Get()`` is a table, we now return and save a copy of the table rather than the original.