### PR TITLE
Add function for invoking OnClose functions

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data.lua
+++ b/src/ServerStorage/Aero/Modules/Data.lua
@@ -498,7 +498,7 @@ function Data:Start()
 		local Bindable = Instance.new("BindableEvent")
 		local numCompleted = 0
 		
-		for _,func in pairs(self.onCloseHandlers) do
+		for _,func in pairs(self._onCloseHandlers) do
 			spawn(function()
 				local success, err = pcall(func)
 				if (not success) then


### PR DESCRIPTION
I noticed there is the method `OnClose` for adding functions to be invoked when the game closes but I saw that there wasn't anything that actually invokes them when the game closes. The `BindToClose` function only auto saves data. So I added `FireBoundToCloseCallbacks` forked from Aero/Services/DataService in the _master_ branch.