### PR TITLE
Add events "Success" and "Failed" for data methods

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data.lua
+++ b/src/ServerStorage/Aero/Modules/Data.lua
@@ -137,7 +137,7 @@ Data._onCloseHandlers = {}
 
 Data.AutoSaveInterval = 60
 Data.PlayerLeftSaveInterval = 10
-Data.SaveInStudio = true
+Data.SaveInStudio = false
 
 local NAME_MAX_LEN = 50
 local SCOPE_MAX_LEN = 50


### PR DESCRIPTION
I like how you get a success response from the data methods but it doesn't allow you to detect a save failure from the auto save loop. So I added the events `Success` and `Failed` like in the master branch DataService implementation.