### PR TITLE
Sustained CamShake doc improvement

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Aero/Modules/CameraShaker/init.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Aero/Modules/CameraShaker/init.lua
@@ -43,7 +43,12 @@
 
 		-- Sustained shake fadeout:
 		swayShakeInstance:StartFadeOut(3)
-	
+
+		-- "CameraShaker.Presets.GentleSway" or any other preset
+		-- will always return a new ShakeInstance. If you want
+		-- to fade out a previously sustained ShakeInstance, you
+		-- will need to assign it to a variable before sustaining it.
+
 	
 	
 	NOTE:

--- a/src/StarterPlayer/StarterPlayerScripts/Aero/Modules/CameraShaker/init.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Aero/Modules/CameraShaker/init.lua
@@ -32,6 +32,17 @@
 		
 		-- Custom shake:
 		camShake:ShakeOnce(3, 1, 0.2, 1.5)
+
+		wait(1)
+
+		-- Sustained shake:
+		local swayShakeInstance = CameraShaker.Presets.GentleSway
+		camShake:ShakeSustain(swayShakeInstance)
+		
+		wait(3)
+
+		-- Sustained shake fadeout:
+		swayShakeInstance:StartFadeOut(3)
 	
 	
 	


### PR DESCRIPTION
Improved the documentation for CameraShakers that have been sustained as I found it to be quite lacking. The old documentation did not clearly convey how to fade out a sustained camShakeInstance. Took me about an hour fiddling around in studio to finally figure it out. (I very nearly submitted an issue for this as I was almost convinced there was no way.)