### PR TITLE
Optimizations and readability fix.

### DIFF
--- a/src/StarterPlayer/StarterPlayerScripts/Aero/Modules/Smooth/SmoothDamp.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Aero/Modules/Smooth/SmoothDamp.lua
@@ -29,4 +29,64 @@
 	
 --]]
 
-local g=Vector3.new local b=math.max local c=math.pi local e=c*2 local f=tick local d=g().Dot local function a(a,b)local a=((b-a)%e)return(a>c and(a-e)or a)end local function c(b,c)return g(a(b.X,c.X),a(b.Y,c.Y),a(b.Z,c.Z))end local function a(b,a)return(b.magnitude>a and(b.unit*a)or b)end local e={}e.__index=e function e.new()local a=setmetatable({MaxSpeed=math.huge;_update=f();_velocity=g()},e)return a end function e:Update(h,i,k)local m=self._velocity local c=f()local f=(c-self._update)k=b(0.0001,k)local g=(2/k)local b=(g*f)local e=(1/(1+b+0.48*b*b+0.235*b*b*b))local l=(h-i)local j=i local b=(self.MaxSpeed*k)l=a(l,b)i=(h-l)local a=((m+g*l)*f)m=((m-g*a)*e)local a=(i+(l+a)*e)if(d(j-h,a-j)>0)then a=j m=((a-j)/f)end self._velocity=m self._update=c return a end function e:UpdateAngle(d,b,a)return self:Update(d,(d+c(d,b)),a)end return e
+
+----------------------------------------------------------------------------------------------------------------
+
+local Vector3_new = Vector3.new
+local math_max = math.max
+local PI = math.pi
+local TAU = PI * 2
+local tick = tick
+
+local function DeltaAngle(current, target)
+	local n = ((target - current) % TAU)
+	return (n > PI and (n - TAU) or n)
+end
+
+local function DeltaAngleV3(p1, p2)
+	return Vector3_new(DeltaAngle(p1.X, p2.X), DeltaAngle(p1.Y, p2.Y), DeltaAngle(p1.Z, p2.Z))
+end
+
+----------------------------------------------------------------------------------------------------------------
+
+local SmoothDamp = {}
+SmoothDamp.__index = SmoothDamp
+
+function SmoothDamp.new()
+	return setmetatable({
+		MaxSpeed = math.huge;
+		_update = tick();
+		_velocity = Vector3_new();
+	}, SmoothDamp)
+end
+
+function SmoothDamp:Update(current, target, smoothTime)
+	local currentVelocity = self._velocity
+	local now = tick()
+	local deltaTime = (now - self._update)
+	smoothTime = math_max(0.0001, smoothTime)
+	local num = (2 / smoothTime)
+	local num2 = (num * deltaTime)
+	local d = (1 / (1 + num2 + 0.48 * num2 * num2 + 0.235 * num2 * num2 * num2))
+	local vector = (current - target)
+	local vector2 = target
+	local maxLength = (self.MaxSpeed * smoothTime)
+	vector = vector.Magnitude > maxLength and (vector.Unit * maxLength) or vector -- Clamp magnitude.
+	target = (current - vector)
+	local vector3 = ((currentVelocity + num * vector) * deltaTime)
+	currentVelocity = ((currentVelocity - num * vector3) * d)
+	local vector4 = (target + (vector + vector3) * d)
+	if ((vector2 - current):Dot(vector4 - vector2) > 0) then
+		vector4 = vector2
+		currentVelocity = ((vector4 - vector2) / deltaTime)
+	end
+	self._velocity = currentVelocity
+	self._update = now
+	return vector4
+end
+
+function SmoothDamp:UpdateAngle(current, target, smoothTime)
+	return self:Update(current, (current + DeltaAngleV3(current, target)), smoothTime)
+end
+
+return SmoothDamp


### PR DESCRIPTION
- It's not smart to be using `local Dot = Vector3.new().Dot`, since it's gonna break eventually and it's not really even a big increase anymore.
- Removed the ClampMagnitude function for just doing the math manually.
- Made the code readable again.

Further optimization can be done however, but it'll cost readability.

- You can replace the `math_max` on line 67 with `0.0001 > smoothTime and 0.0001 or smoothTime`.
- You can replace the `PI` and `TAU` constants in the function `DeltaAngle` with `3.141592653589793115997963468544185161590576171875` and `6.28318530717958623199592693708837032318115234375` respectively.
- You can do remove the `DeltaAngle` functions for just doing the math without the call, but that'll just destroy the readability.