### PR TITLE
Module lifecycle

### DIFF
--- a/src/ServerScriptService/Aero/Internal/AeroServer.server.lua
+++ b/src/ServerScriptService/Aero/Internal/AeroServer.server.lua
@@ -271,6 +271,7 @@ local function Init()
 		end
 	end
 
+	-- Start modules that were already loaded:
 	local function StartLoadedModules()
 		for _,tbl in pairs(modulesAwaitingStart) do
 			FastSpawn(tbl.Start, tbl)

--- a/src/ServerScriptService/Aero/Internal/AeroServer.server.lua
+++ b/src/ServerScriptService/Aero/Internal/AeroServer.server.lua
@@ -21,6 +21,7 @@ local remoteServices = Instance.new("Folder")
 remoteServices.Name = "AeroRemoteServices"
 
 local players = {}
+local modulesAwaitingStart = {}
 
 local FastSpawn = require(internalFolder.FastSpawn)
 
@@ -113,7 +114,11 @@ function AeroServer:WrapModule(tbl)
 		tbl:Init()
 	end
 	if (type(tbl.Start) == "function" and not tbl.__aeroPreventStart) then
-		FastSpawn(tbl.Start, tbl)
+		if (modulesAwaitingStart) then
+			modulesAwaitingStart[#modulesAwaitingStart + 1] = tbl
+		else
+			FastSpawn(tbl.Start, tbl)
+		end
 	end
 end
 
@@ -266,6 +271,13 @@ local function Init()
 		end
 	end
 
+	local function StartLoadedModules()
+		for _,tbl in pairs(modulesAwaitingStart) do
+			FastSpawn(tbl.Start, tbl)
+		end
+		modulesAwaitingStart = nil
+	end
+
 	--------------------------------------------------------------------
 
 	players = game:GetService("Players"):GetPlayers()
@@ -281,6 +293,7 @@ local function Init()
 	InitAllServices(AeroServer.Services)
 	ScanRemoteFoldersForEmpty(remoteServices)
 	StartAllServices(AeroServer.Services)
+	StartLoadedModules()
 	
 	-- Expose server framework to client and global scope:
 	remoteServices.Parent = game:GetService("ReplicatedStorage").Aero


### PR DESCRIPTION
This makes modules respect the Init/Start phases in the lifecycle of the framework. Before, a module required within the `Init` of a service or controller would make the `Init` _and_ `Start` method of the module fire. This pull request will hold off on firing the `Start` method until the proper time within the lifecycle of the framework at startup.

The implementation is simple: If the framework wants to invoke a module's `Start` method, it first checks if the framework has reached that phase of the lifecycle. If not, it queues up the module to be started at a later time.