### PR TITLE
Fix default value when default value was explicitly set to false

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data/init.lua
+++ b/src/ServerStorage/Aero/Modules/Data/init.lua
@@ -486,7 +486,10 @@ function Data:Get(key, defaultVal)
 	-- Load and return value since it was not in the cache:
 	return self:_load(key):Then(function(value)
 		if (value == nil and defaultVal ~= nil) then
-			value = (typeof(defaultVal) ~= "table" and defaultVal or tableUtil.Copy(defaultVal))
+			value = defaultVal
+			if (typeof(defaultVal) == "table") then
+				value = tableUtil.Copy(defaultVal)
+			end
 			return self:Set(key, value):Then(function()
 				return value
 			end)


### PR DESCRIPTION
The Data module had a bug where default values of `false` passed to the `Get` method would throw an error. This was due to faulty logic that resolved the default value using a pseudo-ternary operation. This operation fails when the resultant value that is desired happens to be "falsey" such as this case.

The solution was to simply break this ternary operation out into an `if` statement.