### PR TITLE
Lower default aeroOrder

### DIFF
--- a/docs/execution_model.md
+++ b/docs/execution_model.md
@@ -25,7 +25,7 @@ Services and Controllers act as singletons. In other words, only one instance ex
 
 The order of which `Init` is invoked for services and controllers can be explicitly set. This is done through the `__aeroOrder` field.
 
-Simply set the service or controller `__aeroOrder` field to a number. The `Init` process will execute based on ascending order. Services and controllers without an `__aeroOrder` field set will be executed last (technically, the default order is set to `math.huge`).
+Simply set the service or controller `__aeroOrder` field to a number. The `Init` process will execute based on ascending order. Services and controllers without an `__aeroOrder` field have it set to `4096` by default, meaning that a module with a greater `__aeroOrder` than `4096` will have `Init` called after all unset modules have loaded.
 
 !!! note
 	The `__aeroOrder` field can be any valid number, including negatives and non-whole numbers. See the examples under the [Services](services.md#forcing-init-order) and [Controllers](controllers.md#forcing-init-order) page.

--- a/src/ServerScriptService/Aero/Internal/AeroServer.server.lua
+++ b/src/ServerScriptService/Aero/Internal/AeroServer.server.lua
@@ -299,8 +299,8 @@ local function Init()
 		CollectServices(services)
 		-- Sort services by optional __aeroOrder field:
 		table.sort(serviceTables, function(a, b)
-			local aOrder = (type(a.__aeroOrder) == "number" and a.__aeroOrder or math.huge)
-			local bOrder = (type(b.__aeroOrder) == "number" and b.__aeroOrder or math.huge)
+			local aOrder = (type(a.__aeroOrder) == "number" and a.__aeroOrder or 4096)
+			local bOrder = (type(b.__aeroOrder) == "number" and b.__aeroOrder or 4096)
 			return (aOrder < bOrder)
 		end)
 		-- Initialize services:

--- a/src/StarterPlayer/StarterPlayerScripts/Aero/Internal/AeroClient.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Aero/Internal/AeroClient.client.lua
@@ -221,8 +221,8 @@ local function Init()
 		CollectControllers(controllers)
 		-- Sort controllers by optional __aeroOrder field:
 		table.sort(controllerTables, function(a, b)
-			local aOrder = (type(a.__aeroOrder) == "number" and a.__aeroOrder or math.huge)
-			local bOrder = (type(b.__aeroOrder) == "number" and b.__aeroOrder or math.huge)
+			local aOrder = (type(a.__aeroOrder) == "number" and a.__aeroOrder or 4096)
+			local bOrder = (type(b.__aeroOrder) == "number" and b.__aeroOrder or 4096)
 			return (aOrder < bOrder)
 		end)
 		-- Initialize controllers:


### PR DESCRIPTION
I think that there is a use case for running `Init` on a module after all other modules have loaded, but before `Start` is called. An example of this use case is a [binder](https://github.com/Quenty/NevermoreEngine/blob/version2/Modules/Shared/Binder/Binder.lua) - everything else must be loaded for it to start creating lua objects, but it cannot be run on `Start` as other modules rely on the objects already existing.

By lowering the order from `math.huge` to any non-infinite number (I chose `4096`) modules can be run after the default ones have been loaded by setting their order to a number above `4096`.