### PR TITLE
Wrap ProfileService studio check in coroutine

### DIFF
--- a/src/ServerStorage/Aero/Modules/ProfileService.lua
+++ b/src/ServerStorage/Aero/Modules/ProfileService.lua
@@ -1573,17 +1573,19 @@ end
 ----- Initialize -----
 
 if IsStudio == true then
-	local status, message = pcall(function()
-		-- This will error if current instance has no Studio API access:
-		DataStoreService:GetDataStore("____PS"):SetAsync("____PS", os.time())
-	end)
-	if status == false and (string.find(message, "403", 1, true) ~= nil or string.find(message, "must publish", 1, true) ~= nil) then
-		UseMockDataStore = true
-		ProfileService._use_mock_data_store = true
-		print("[ProfileService]: Roblox API services unavailable - data will not be saved")
-	else
-		print("[ProfileService]: Roblox API services available - data will be saved")
-	end
+	coroutine.wrap(function()
+		local status, message = pcall(function()
+			-- This will error if current instance has no Studio API access:
+			DataStoreService:GetDataStore("____PS"):SetAsync("____PS", os.time())
+		end)
+		if status == false and (string.find(message, "403", 1, true) ~= nil or string.find(message, "must publish", 1, true) ~= nil) then
+			UseMockDataStore = true
+			ProfileService._use_mock_data_store = true
+			print("[ProfileService]: Roblox API services unavailable - data will not be saved")
+		else
+			print("[ProfileService]: Roblox API services available - data will be saved")
+		end
+	end)()
 end
 
 ----- Connections -----


### PR DESCRIPTION
ProfileService makes a datastore call when initializing which causes the metamethod to yield. Although this only occurs in studio, it causes the entire framework to break. Wrapping the call in a coroutine fixed the issue.