### PR TITLE
Simplified VectorUtil.ClampMagnitude

### DIFF
--- a/src/ReplicatedStorage/Aero/Shared/VectorUtil.lua
+++ b/src/ReplicatedStorage/Aero/Shared/VectorUtil.lua
@@ -44,7 +44,7 @@ local VectorUtil = {}
 
 
 function VectorUtil.ClampMagnitude(vector, maxMagnitude)
-	return (vector.Magnitude > maxMagnitude and (vector.Unit * maxMagnitude) or vector)
+	return vector.Unit * maxMagnitude
 end
 
 


### PR DESCRIPTION
VectorUtil had a redundant ternary operation that could be made simpler.
Functionally it's the same, except it looks cleaner and has a very small performance increase.