### PR TITLE
Add text to load screen

### DIFF
--- a/src/ReplicatedFirst/Aero/AeroLoad.client.lua
+++ b/src/ReplicatedFirst/Aero/AeroLoad.client.lua
@@ -31,7 +31,17 @@ do
 	frame.AnchorPoint = Vector2.new(0.5, 0.5)
 	frame.Size = UDim2.new(2, 0, 2, 0)
 	frame.BackgroundColor3 = Color3.new(0, 0, 0)
+	local overlayText = Instance.new("TextLabel")
+	overlayText.Name = "LoadingText"
+	overlayText.AnchorPoint = Vector2.new(0.5, 0.5)
+	overlayText.Position = UDim2.new(0.5,0,0.5,0)
+	overlayText.Size = UDim2.new(0.3,0,0.1,0)
+	overlayText.TextScaled = true
+	overlayText.BackgroundTransparency = 1
+	overlayText.TextColor3 = Color3.new(255,255,255)
+	overlayText.Text = "Loading Game."
 	frame.Parent = tempBlackout
+	overlayText.Parent = tempBlackout
 end
 
 -- Remove default loading screen & replace with a temporary black overlay:


### PR DESCRIPTION
I entered a game that used AGF and its starter loading screen code. Many of its players complained about its loading screen because especially when the game size is large, loading into a completely black screen raises questions if it is a bug or if connection to the game failed. Adding a simple loading text would clear the confusion and perhaps increase retention for games that use the starter loading screen.