### PR TITLE
Fixed a line calling SaveAll() with unnecessary arguments in Data

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data/init.lua
+++ b/src/ServerStorage/Aero/Modules/Data/init.lua
@@ -632,7 +632,7 @@ function Data:Destroy(save)
 	self._destroying = true
 	local savePromise
 	if (save) then
-		savePromise = self:SaveAll(false, nil)
+		savePromise = self:SaveAll()
 	else
 		savePromise = Promise.Resolve()
 	end


### PR DESCRIPTION
A minor thing I found in the Data module but it is still worth fixing as those arguments seem to be of no use in the SaveAll() method.