### PR TITLE
Fix redundant parameters

### DIFF
--- a/src/ServerStorage/Aero/Modules/Data/init.lua
+++ b/src/ServerStorage/Aero/Modules/Data/init.lua
@@ -632,7 +632,7 @@ function Data:Destroy(save)
 	self._destroying = true
 	local savePromise
 	if (save) then
-		savePromise = self:SaveAll(false, nil)
+		savePromise = self:SaveAll()
 	else
 		savePromise = Promise.Resolve()
 	end


### PR DESCRIPTION
My 'Roblox LSP' VSCode extension detected the usage of some redundant parameters in the Data module. This should make sense, since `Data:SaveAll()` does not expect any parameters.
```lua
function Data:SaveAll()
	if (self._destroyed) then
		return Promise.Reject("Data already destroyed")
	end
	-- Collect all 'Save' promises and return them all in a single promise:
	local promises = {}
	for key in pairs(self._cache) do
		promises[#promises + 1] = self:Save(key)
	end
	return Promise.All(promises)
end
```